### PR TITLE
Integrate feedback received on draft charter

### DIFF
--- a/wg-charter.html
+++ b/wg-charter.html
@@ -51,6 +51,7 @@
         <ul id="navbar">
           <li><a href="#scope">Scope</a></li>
           <li><a href="#deliverables">Deliverables</a></li>
+          <li><a href="#success-criteria">Success criteria</a></li>
           <li><a href="#coordination">Coordination</a></li>
           <li><a href="#participation">Participation</a></li>
           <li><a href="#communication">Communication</a></li>
@@ -61,13 +62,15 @@
         </ul>
       </aside>
       <p>
-        <a href="https://www.w3.org/"><img alt="W3C" height="48" src="http://www.w3.org/Icons/w3c_home" width="72" /></a>
+        <a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72" /></a>
 
       </p>
     </header>
 
     <main>
-      <h1 id="title">GPU for the Web Working Group Charter</h1>
+      <h1 id="title"><i class="todo">PROPOSED</i> GPU for the Web Working Group Charter</h1>
+
+      <p class="todo"><strong>Warning:</strong> This document has no official status. It is a draft charter for discussion within the GPU for the Web Community Group and the W3C Advisory Committee.</p>
 
       <p class="mission">The <strong>mission</strong> of the <a
       href="https://www.w3.org/gpuweb/">GPU for the Web Working Group</a> is to
@@ -93,7 +96,7 @@
               End date
             </th>
             <td>
-              TBD
+              TBD (2 years after start date)
             </td>
           </tr>
 
@@ -118,9 +121,10 @@
               Meeting Schedule
             </th>
             <td>
-              <strong>Teleconferences:</strong> as necessary.
+              <strong>Teleconferences:</strong> weekly or bi-weekly calls, as necessary.
               <br />
-              <strong>Face-to-face:</strong> as necessary.
+              <strong>Face-to-face:</strong> 3 times per year as necessary,
+              including during W3C's annual Technical Plenary week.
             </td>
           </tr>
         </table>
@@ -130,6 +134,12 @@
 
       <section id="scope" class="scope">
         <h2>Scope</h2>
+        <p>
+            In this document, the term <dfn>GPU</dfn> stands for Graphics
+            Processing Unit, typically a piece of hardware dedicated to
+            efficiently processing graphics and related features.
+        </p>
+
         <p>
             This Working Group will recommend a Web programming interface for
             graphics and computation that:
@@ -144,7 +154,7 @@
 
         <p>
             The API will not be restricted to any particular platform technology. Instead, it will
-            be generic enough to be implemented on top of modern GPU libraries, such as
+            be generic enough to be implemented on top of modern GPU system APIs, such as
             Microsoft's Direct3D 12, Apple's Metal, and Khronos's Vulkan.
         </p>
 
@@ -154,14 +164,6 @@
             No major development will happen in the Working Group itself. Instead, the Community
             Group will be driving the technical work.
         </p>
-
-        <div>
-          <h3>Success Criteria</h3>
-          <p>In order to advance to  <a href="https://www.w3.org/2018/Process-20180201/#RecsCR" title="Proposed Recommendation">Proposed Recommendation</a>, each specification is expected to have at least two independent implementations of each of feature defined in the specification.</p>
-          <p>The WebGPU specification should contain a section detailing any <a href='https://www.w3.org/TR/security-privacy-questionnaire/'>known security</a>, fingerprinting, and privacy implications, and suggested <a href='https://w3c.github.io/perf-security-privacy/'>mitigation strategies</a> for implementers, Web authors, and end users. The group should not publish a specification if acceptable mitigation strategies cannot be found.</p>
-          <p>The WebGPU specification should contain a section describing known impacts on accessibility to users with disabilities, ways the specification features address them, and recommendations for minimizing accessibility problems in implementation.</p>
-          <p>Normative specification changes are generally expected to have a corresponding set of tests, either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the proposed update.</p>
-        </div>
 
         <h2>Out of Scope</h2>
         <p>
@@ -183,25 +185,17 @@
 
         <div id="normative">
           <h3>
-            Normative
+            Normative Specifications
           </h3>
           <dl>
           <dt>WebGPU API</dt>
 
           <dd>
-              An API as described by the <a
-              href="https://www.w3.org/community/gpu/">GPU for the Web
-              Community Group</a> charter.
-              <p class="milestone"><b>Recommendation expected completion:</b> Q2 2020</p>
+              An API for performing operations, such as rendering and
+              computation, on a Graphics Processing Unit (GPU).
+              <p class="draft-status"><b>Draft state:</b> <a href="https://gpuweb.github.io/gpuweb/">Adopted from the GPU for the Web Community Group</a></p>
+              <p class="milestone"><b>Recommendation expected completion:</b> Q3 2021</p>
           </dd>
-
-          <dt>WebGPU Test Suite</dt>
-
-          <dd>
-              A conformance test suite for the WebGPU API.
-              <p class="milestone"><b>Expected delivery:</b> Q2 2020</p>
-          </dd>
-
           </dl>
 
           <h3>
@@ -221,14 +215,30 @@
 
         <div id="wg-other-deliverables">
             <h3>
-              Other deliverables
+              Other Deliverables
             </h3>
             <p>
-                The GPU for the Web Community group will produce deliverables to be
-                used within this Working Group. In particular, a conformance test suite
-                and possibly reference implementations.
+              This Working Group will produce conformance test suites and
+              implementation reports for its normative deliverables.
             </p>
+            <p>
+              Other non-normative documents may be created, including:
+            </p>
+            <ul>
+              <li>Reference implementations of the group's deliverables</li>
+              <li>Use case and requirement documents</li>
+              <li>Explainers, primers and best-practice documents</li>
+            </ul>
         </div>
+      </section>
+
+
+      <section id="success-criteria">
+        <h2>Success Criteria</h2>
+        <p>In order to advance to  <a href="https://www.w3.org/2018/Process-20180201/#RecsCR" title="Proposed Recommendation">Proposed Recommendation</a>, each specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations of each feature defined in the specification</a>.</p>
+        <p>Each specification should contain a section detailing any <a href='https://www.w3.org/TR/security-privacy-questionnaire/'>known security</a>, fingerprinting, and privacy implications, and suggested <a href='https://w3c.github.io/perf-security-privacy/'>mitigation strategies</a> for implementers, web authors, and end users. The group should not publish a specification if acceptable mitigation strategies cannot be found.</p>
+        <p>Each specification should contain a section describing known impacts on accessibility to users with disabilities, ways the specification features address them, and recommendations for minimizing accessibility problems in implementation.</p>
+        <p>Normative specification changes are generally expected to have a corresponding set of tests, either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the proposed update.</p>
       </section>
 
 
@@ -244,14 +254,17 @@
             <dt><a href="https://www.w3.org/2001/tag/">Technical Architecture Group (TAG)</a></dt>
         <dd>The WG may ask the Technical Architecture Group to review some of its specifications.</dd>
 
-        <dt><a href="https://www.w3.org/WebPlatform/WG/">Web Platform Working Group</a></dt>
-        <dd>This Working Group develops APIs for client-side development and for markup vocabularies for describing and controlling client-side application behavior.</dd>
+        <dt><a href="https://www.w3.org/2019/webapps/">Web Applications Working Group</a></dt>
+        <dd>The Web Applications Working Group (WebApps WG) produces specifications that facilitate the development of client-side web applications.</dd>
 
         <dt><a href="https://www.w3.org/2011/webappsec/">Web Application Security Working Group</a></dt>
         <dd>This Working Group develops security and policy mechanisms to improve the security of Web Applications, and enable secure cross-site communication.</dd>
 
         <dt><a href="https://www.w3.org/wasm/">Web Assembly Working Group</a></dt>
         <dd>This Working Group develops a size- and load-time-efficient format and execution environment, allowing compilation to the web with consistent behavior across a variety of implementations.</dd>
+
+        <dt><a href="https://www.w3.org/community/webmachinelearning/">Machine Learning for the Web Community Group</a></dt>
+        <dd>This Community Group incubates a dedicated low-level Web API for machine learning inference.</dd>
 
         <dt><a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a></dt>
         <dd>
@@ -286,7 +299,13 @@
           The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
         </p>
         <p>
-          As stated above, the majority of the technical work for Working Group will take place in the <a href="https://www.w3.org/community/gpu/">GPU for the Web Community Group</a>.
+          Participants in the group are required
+          (by the <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>)
+          to follow the W3C
+          <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.
+        </p>
+        <p>
+          As stated above, the majority of the technical work for this Working Group will take place in the <a href="https://www.w3.org/community/gpu/">GPU for the Web Community Group</a>.
         </p>
       </section>
 
@@ -370,13 +389,13 @@
 
       <p class="copyright">
         <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-        2018
+        2020
         <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (
         <a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
-        <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-        <a href="http://www.keio.ac.jp/">Keio</a>,
-        <a href="http://ev.buaa.edu.cn/">Beihang</a>
+        <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="https://www.keio.ac.jp/">Keio</a>,
+        <a href="https://ev.buaa.edu.cn/">Beihang</a>
         ), All Rights Reserved.
 
         <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.


### PR DESCRIPTION
List of changes:
- Flagged the charter as "proposed" and added a warning that this is a draft document.
- Set duration expectation (2 years)
- Started the charter with a definition of the term GPU to clarify context.
- Replaced "GPU libraries" by "GPU system APIs" in Participation
- Moved Success criteria section out of the Scope section
- Replaced "WebGPU specification" by "Each specification" in Success Criteria so that text applies to all group deliverables
- Linked to Process document for definition of "at least two independent
implementations"
- Dropped WebGPU Test Suite from the list of deliverables (that is still a must have for the group, just not a deliverable) and renamed section to "Normative Specifications"
- Added link to adopted CG draft for the WebGPU specification
- Updated completion milestone for WebGPU specification to Q3 2021
- Replaced description of WebGPU deliverable with the abstract of the spec.
- Added boilerplate text to mention the code of ethics in "Participation"
- Updated teleconferences and F2F expectations based on group history
- Replaced Web Platform by Web Applications in list of relevant W3C groups
- Added Machine Learning for the Web Community Group to relevant W3C groups
- Reformulated Other Deliverables section to restrict the list of deliverables (especially normative) that the group could adopt. The section explicitly mentions test suites and implementation reports, and now uses more boilerplate text for other potential non-normative documents. Also dropped mention of the CG since the Scope section already explains that the majority of the input will come from it)
- Updated copyright statement
- Fixed a couple of typos
- s/http/https where needed